### PR TITLE
Add Event.__hash__ to ensure results are consistent.

### DIFF
--- a/poly_point_isect.py
+++ b/poly_point_isect.py
@@ -120,6 +120,9 @@ class Event:
             self.other = None
             self.in_sweep = False
 
+    def __hash__(self):
+        return hash(self.point)
+
     def is_vertical(self):
         # return self.segment[0][X] == self.segment[1][X]
         return self.span == NUM_ZERO


### PR DESCRIPTION
Non-deterministic results are because Event is being hashed by memory address. This means equal sets of events are iterated in different orders.  This makes the results repeatable, but it also seems like it means ties are being broken based on iteration order, which seems less than ideal.

This fixes #7.