### PR TITLE
Avoid needlessly calling str() when raising KeyError.

### DIFF
--- a/poly_point_isect.py
+++ b/poly_point_isect.py
@@ -821,7 +821,7 @@ class _ABCTree(object):
                 node = node.left
             else:
                 node = node.right
-        raise KeyError(str(key))
+        raise KeyError(key)
 
     def pop_item(self):
         """T.pop_item() -> (k, v), remove and return some (key, value) pair as a


### PR DESCRIPTION
Removing the call to `__str__` speeds up the following example
(admittedly slightly aritificial) by ~5%, with no disadvantage
(exceptions will automatically call `repr` on their argument if a
traceback actually needs to be displayed):
```
from poly_point_isect import *
import random
from timeit import Timer

random.seed(1)
points = [(random.random(), random.random()) for _ in range(200)]
n, t = Timer("isect_polygon(points)", globals=globals()).autorange()
print(t/n)
```